### PR TITLE
Add an arg for a custom directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Lets you test a pull-request on the Jenkins project in a clean environment.
 $ docker run --rm -ti -p 8080:8080 -e ID=2200 jenkins/core-pr-tester
 ```
 
+### How to change the Jenkins home directory
+
+The Jenkins home directory can be set with `JENKINS_HOME` as an environment variable.
+
+```shell
+$ docker run --rm -ti -p 8080:8080 -e ID=2200 -e JENKINS_HOME=/custom/directory/path jenkins/core-pr-tester
+```
+
 ### How to merge with `master` branch
 
 An additional environment variable `MERGE_WITH=` can be passed to merge the PR with any existing branch from the repository, before starting the build.

--- a/checkout-and-start.sh
+++ b/checkout-and-start.sh
@@ -26,7 +26,7 @@ fi
 
 mvn --no-transfer-progress -V -pl war --also-make clean package -DskipTests -Dmaven.test.skip=true -P quick-build
 
-if [[ ${JENKINS_HOME:-} != "" ]]; then
+if [[ -n ${JENKINS_HOME-} ]]; then
     export JENKINS_HOME=$JENKINS_HOME
     echo "Jenkins home directory changed to $JENKINS_HOME"
 else

--- a/checkout-and-start.sh
+++ b/checkout-and-start.sh
@@ -26,5 +26,12 @@ fi
 
 mvn --no-transfer-progress -V -pl war --also-make clean package -DskipTests -Dmaven.test.skip=true -P quick-build
 
+if [[ ${JENKINS_HOME:-} != "" ]]; then
+    export JENKINS_HOME=$JENKINS_HOME
+    echo "Jenkins home directory changed to $JENKINS_HOME"
+else
+    echo "Using default home directory"
+fi
+
 echo "Starting Jenkins"
 java -jar war/target/jenkins.war

--- a/checkout-and-start.sh
+++ b/checkout-and-start.sh
@@ -27,7 +27,6 @@ fi
 mvn --no-transfer-progress -V -pl war --also-make clean package -DskipTests -Dmaven.test.skip=true -P quick-build
 
 if [[ -n ${JENKINS_HOME-} ]]; then
-    export JENKINS_HOME=$JENKINS_HOME
     echo "Jenkins home directory changed to $JENKINS_HOME"
 else
     echo "Using default home directory"


### PR DESCRIPTION
If not set, JENKINS_HOME is relative to your root directory, if you build a core PR with the core-pr-tester. 

This PR adds `JENKINS_HOME` as an argument you can use to change the directory to a different location, if desired. 