### PR TITLE
Run GH actions on ubuntu-latest rather than a specific ubuntu version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
  
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
  
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Equals to 20.04 at the moment, but rotates to newer LTS versions periodically.