### PR TITLE
Build with Java 21 and jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-focal
+FROM eclipse-temurin:21-jdk-jammy
 
 ARG MAVEN_VERSION=3.9.6
 # https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz.sha512


### PR DESCRIPTION
We're moving closer to Java 21 day by day, and building the dockerfile with Java 21 for core PR testing is just another step into the right direction.